### PR TITLE
feat: Enable deterministic source switching for Samsung Soundbars via self-learning mapping

### DIFF
--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import json
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -87,6 +89,9 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             self._attr_device_class = MediaPlayerDeviceClass.TV
         else:
             self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
+            #Variables used to map source names to source IDs
+            config_dir = os.path.dirname(__file__)
+            self._source_maps_dir = os.path.join(config_dir, "source_maps")
 
     @property
     def supported_features(self) -> int:
@@ -276,6 +281,8 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
     @property
     def source(self) -> str | None:
         if self.device.has_capability("samsungvd.audioInputSource"):
+            if getattr(self, "_source_maps_dir", None) is not None:
+                self.hass.async_create_task(self.async_update_source_map())
             v = self.device.get_attr("samsungvd.audioInputSource", "inputSource")
             return str(v) if v is not None else None
 
@@ -290,7 +297,19 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             raw_sources = self.device.get_attr("samsungvd.audioInputSource", "supportedInputSources")
             
             if isinstance(raw_sources, list):
-                return [str(s) for s in raw_sources]
+                sources = [str(s) for s in raw_sources]
+                
+                # NOTE FOR MAINTAINER REGARDING BLUETOOTH EDGE CASE:
+                # Some Samsung soundbars freeze their SmartThings API telemetry when on Bluetooth.
+                # If the integration is reloaded while the device is on Bluetooth, it can cause 
+                # the media_player entity to initialize as 'unavailable' until switched back to HDMI/Wifi.
+                # 
+                # Only half fix i could think of was removing it from the list, but its not good production code so i left it like this, 
+                #
+                # if "bluetooth" in sources:
+                #     sources.remove("bluetooth")
+                #     _LOGGER.info("🚫 [SmartThings Soundbar] Hidden 'bluetooth' from source list to prevent API freeze during reload.")
+                return sources
  
         return []
 
@@ -304,31 +323,16 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             return
 
         if self.device.has_capability("samsungvd.audioInputSource"):
-            
-            model_name = self.device.get_attr("ocf", "mnmo")
-            #Hardcoded source map atm, but moving over self learning source map from old integration later
-            source_map = {
-                "HDMI1": {"sbMode": 3},
-                "HDMI2": {"sbMode": 20},
-                "digital": {"sbMode": 10},
-                "wifi": {"sbMode": 25},
-            }
-            if model_name == "HW-S60T":
-                source_map = {
-                   "bluetooth": {"sbMode": 4},
-                    "digital": {"sbMode": 1},
-                    "wifi": {"sbMode": 26},
-                }
-
+            source_map = await self.async_get_source_map()
+            if not source_map:
+                return
             if source not in source_map:
                 _LOGGER.warning(
-                    "Source not found: %s in source map: %s for model: ",
-                    source,
-                    source_map,
-                    exc.model_name,
+                    "Source %s not found in source map %s. Please perform a manual source change with the remote, "
+                    "wait for the device to update, and it will be learned automatically by the integration.", 
+                    source, source_map
                 )
                 return
-
             await self.device.send_command(
                 capability="execute",
                 command="execute",
@@ -342,6 +346,119 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
                 ]
             )
             await self.coordinator.async_request_refresh()
+
+
+####### START of code for self learning source map #####################
+
+    def _sync_get_source_map(self, safe_model_name: str) -> dict:
+        """Triggers inside the executor thread to safely read from disk."""
+        model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
+        default_file_path = os.path.join(self._source_maps_dir, "default_source_map.json")
+
+        if os.path.exists(model_file_path):
+            try:
+                with open(model_file_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                _LOGGER.error("Error reading source map file for %s: %s", safe_model_name, e)
+
+        if safe_model_name == "default" and os.path.exists(default_file_path):
+            try:
+                with open(default_file_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                _LOGGER.error("Error reading default_source_map.json: %s", e)
+
+        defaults = {
+            "HDMI1": {"sbMode": 3},
+            "HDMI2": {"sbMode": 20},
+            "digital": {"sbMode": 10},
+            "wifi": {"sbMode": 25}
+        }
+    
+        if not os.path.exists(default_file_path):
+            try:
+                os.makedirs(self._source_maps_dir, exist_ok=True)
+                with open(default_file_path, "w", encoding="utf-8") as f:
+                    json.dump(defaults, f, indent=4)
+            except Exception as e:
+                _LOGGER.error("Could not write default source map file to disk: %s", e)
+
+        return defaults
+
+    async def async_get_source_map(self) -> dict:
+        """Asynchronously gets the source map without blocking the event loop."""
+        if not hasattr(self, "_source_maps_dir") or not self._source_maps_dir:
+            return {}
+
+        tmp = self.device.get_attr("ocf", "mnmo") 
+        model_name = tmp if tmp is not None else "default"
+        safe_model_name = "".join(c for c in model_name if c.isalnum() or c in ("-", "_")).strip()
+        if not safe_model_name:
+            safe_model_name = "default"
+
+        return await self.hass.async_add_executor_job(self._sync_get_source_map, safe_model_name)
+
+    def _sync_write_source_map(self, safe_model_name: str, model_map: dict) -> None:
+        """Triggers inside the executor thread to safely write to disk."""
+
+        model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
+        try:
+            os.makedirs(self._source_maps_dir, exist_ok=True)
+            with open(model_file_path, "w", encoding="utf-8") as f:
+                json.dump(model_map, f, indent=4)
+        except Exception as e:
+            _LOGGER.error("Could not save learned source to %s: %s", model_file_path, e)
+
+    async def async_update_source_map(self) -> None:
+        """Asynchronously updates the specific model's JSON file when a new source is found."""
+        if not hasattr(self, "_source_maps_dir") or not self._source_maps_dir:
+            return
+
+        model_name = self.device.get_attr("ocf", "mnmo")
+        sb_mode = self.device.get_attr("samsungvd.soundFrom", "mode")
+        source_name = self.device.get_attr("samsungvd.audioInputSource", "inputSource")
+        if source_name is None or sb_mode is None or model_name is None:
+            return
+
+        current_map = await self.async_get_source_map()
+
+        safe_model_name = "".join(c for c in model_name if c.isalnum() or c in ("-", "_")).strip()
+        if not safe_model_name:
+            safe_model_name = "default"
+        
+        if source_name in current_map and current_map[source_name].get("sbMode") == sb_mode:
+            if safe_model_name == "default":
+                return
+            model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
+            if await self.hass.async_add_executor_job(os.path.exists, model_file_path):
+                return
+
+        model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
+        model_map = {}
+        
+        if await self.hass.async_add_executor_job(os.path.exists, model_file_path):
+            def read_existing():
+                with open(model_file_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            try:
+                model_map = await self.hass.async_add_executor_job(read_existing)
+            except Exception as e:
+                _LOGGER.error("Could not read existing file for %s before update: %s", safe_model_name, e)
+        else:
+            model_map = current_map.copy()
+
+        model_map[source_name] = {"sbMode": sb_mode}
+
+        await self.hass.async_add_executor_job(self._sync_write_source_map, safe_model_name, model_map)
+        
+        _LOGGER.warning(
+            "💾 [SmartThings Soundbar] New source learned for %s: %s -> %s! "
+            "To make it permanent, please open a quick GitHub PR and upload this file: %s", 
+            model_name, source_name, sb_mode, model_file_path
+        )
+
+####### END of code for self learning source map #####################
 
 class SoundbarLocalMediaPlayer(MediaPlayerEntity):
     """2024-line Samsung soundbar over LAN (HTTPS JSON-RPC on port 1516)."""

--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -352,6 +352,17 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
 
     def _sync_get_source_map(self, safe_model_name: str) -> dict:
         """Triggers inside the executor thread to safely read from disk."""
+        if not os.path.exists(self._source_maps_dir):
+            try:
+                os.makedirs(self._source_maps_dir)
+            except Exception as e:
+                _LOGGER.error("Could not create source maps directory. Error: %s\nFallback to default", e)
+                return {
+                    "HDMI1": {"sbMode": 3},
+                    "HDMI2": {"sbMode": 20},
+                    "digital": {"sbMode": 10},
+                    "wifi": {"sbMode": 25}
+                }
         model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
         default_file_path = os.path.join(self._source_maps_dir, "default_source_map.json")
 
@@ -435,18 +446,7 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
                 return
 
         model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
-        model_map = {}
-        
-        if await self.hass.async_add_executor_job(os.path.exists, model_file_path):
-            def read_existing():
-                with open(model_file_path, "r", encoding="utf-8") as f:
-                    return json.load(f)
-            try:
-                model_map = await self.hass.async_add_executor_job(read_existing)
-            except Exception as e:
-                _LOGGER.error("Could not read existing file for %s before update: %s", safe_model_name, e)
-        else:
-            model_map = current_map.copy()
+        model_map = current_map.copy()
 
         model_map[source_name] = {"sbMode": sb_mode}
 

--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -107,6 +107,8 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             f |= F.NEXT_TRACK | F.PREVIOUS_TRACK
         if self.device.has_capability("custom.launchapp"):
             f |= F.PLAY_MEDIA | F.SELECT_SOURCE
+        if not self.device.has_capability("custom.launchapp") and self.device.has_capability("samsungvd.audioInputSource"):
+            f |= F.SELECT_SOURCE 
         # Source selection is handled via select entity; keep here minimal.
         return _FeatureMask(f)
 
@@ -271,20 +273,62 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
     def media_artist(self) -> str | None:
         _title, artist = self.device.get_media_metadata()
         return artist
+    @property
+    def source(self) -> str | None:
+        if self.device.has_capability("samsungvd.audioInputSource"):
+            v = self.device.get_attr("samsungvd.audioInputSource", "inputSource")
+            return str(v) if v is not None else None
 
+        return None
+    
     @property
     def source_list(self) -> list[str]:
-        if not self.device.has_capability("custom.launchapp"):
-            return []
-        return app_options()
+        if self.device.has_capability("custom.launchapp"):
+            return app_options()
+            
+        if self.device.has_capability("samsungvd.audioInputSource"):
+            raw_sources = self.device.get_attr("samsungvd.audioInputSource", "supportedInputSources")
+            
+            if isinstance(raw_sources, list):
+                return [str(s) for s in raw_sources]
+            return list(self._source_map.keys())
+            
+        return []
 
     async def async_select_source(self, source: str) -> None:
-        app = resolve_app(source)
-        if app is None:
-            raise HomeAssistantError(f"Unknown app source: {source}")
-        await self.device.send_command("custom.launchapp", "launchApp", arguments=[app.app_id, app.name])
-        await self.coordinator.async_request_refresh()
+        if self.device.has_capability("custom.launchapp"):
+            app = resolve_app(source)
+            if app is None:
+                raise HomeAssistantError(f"Unknown app source: {source}")
+            await self.device.send_command("custom.launchapp", "launchApp", arguments=[app.app_id, app.name])
+            await self.coordinator.async_request_refresh()
+            return
 
+        if self.device.has_capability("samsungvd.audioInputSource"):
+            model_name = self.device_info.get("model") if self.device_info else "default"
+            source_map = {
+                "HDMI1": {"sbMode": 3},
+                "HDMI2": {"sbMode": 20},
+                "digital": {"sbMode": 10},
+                "wifi": {"sbMode": 25},
+            }
+
+            if source not in source_map:
+                return
+
+            await self.device.send_command(
+                capability="execute",
+                command="execute",
+                arguments=[
+                    "/sec/networkaudio/soundFrom",
+                    {
+                        "x.com.samsung.networkaudio.soundFrom": {
+                            "sbMode": source_map[source]["sbMode"]
+                        }
+                    }
+                ]
+            )
+            await self.coordinator.async_request_refresh()
 
 class SoundbarLocalMediaPlayer(MediaPlayerEntity):
     """2024-line Samsung soundbar over LAN (HTTPS JSON-RPC on port 1516)."""

--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -291,8 +291,7 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             
             if isinstance(raw_sources, list):
                 return [str(s) for s in raw_sources]
-            return list(raw_sources.keys())
-            
+ 
         return []
 
     async def async_select_source(self, source: str) -> None:

--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
-
+import logging
 from homeassistant.components.media_player import (
     BrowseMedia,
     MediaClass,
@@ -31,7 +31,7 @@ from .frame_local_api import AsyncFrameLocal
 from .soundbar_local_api import AsyncSoundbarLocal
 from .app_catalog import YOUTUBE_APP, app_options, is_http_url, is_youtube_url, resolve_app
 
-
+_LOGGER = logging.getLogger(__name__)
 class _FeatureMask(int):
     """Int mask that also supports `feature in mask` membership checks."""
 
@@ -291,7 +291,7 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             
             if isinstance(raw_sources, list):
                 return [str(s) for s in raw_sources]
-            return list(self._source_map.keys())
+            return list(raw_sources.keys())
             
         return []
 
@@ -305,15 +305,29 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             return
 
         if self.device.has_capability("samsungvd.audioInputSource"):
-            model_name = self.device_info.get("model") if self.device_info else "default"
+            
+            model_name = self.device.get_attr("ocf", "mnmo")
+            #Hardcoded source map atm, but moving over self learning source map from old integration later
             source_map = {
                 "HDMI1": {"sbMode": 3},
                 "HDMI2": {"sbMode": 20},
                 "digital": {"sbMode": 10},
                 "wifi": {"sbMode": 25},
             }
+            if model_name == "HW-S60T":
+                source_map = {
+                   "bluetooth": {"sbMode": 4},
+                    "digital": {"sbMode": 1},
+                    "wifi": {"sbMode": 26},
+                }
 
             if source not in source_map:
+                _LOGGER.warning(
+                    "Source not found: %s in source map: %s for model: ",
+                    source,
+                    source_map,
+                    exc.model_name,
+                )
                 return
 
             await self.device.send_command(

--- a/custom_components/samsung_smartthings/media_player.py
+++ b/custom_components/samsung_smartthings/media_player.py
@@ -356,13 +356,8 @@ class SamsungSmartThingsMediaPlayer(SamsungSmartThingsEntity, MediaPlayerEntity)
             try:
                 os.makedirs(self._source_maps_dir)
             except Exception as e:
-                _LOGGER.error("Could not create source maps directory. Error: %s\nFallback to default", e)
-                return {
-                    "HDMI1": {"sbMode": 3},
-                    "HDMI2": {"sbMode": 20},
-                    "digital": {"sbMode": 10},
-                    "wifi": {"sbMode": 25}
-                }
+                _LOGGER.error("Could not create source maps directory. Error: %s", e)
+
         model_file_path = os.path.join(self._source_maps_dir, f"{safe_model_name}_source_map.json")
         default_file_path = os.path.join(self._source_maps_dir, "default_source_map.json")
 

--- a/custom_components/samsung_smartthings/source_maps/HW-Q910A_source_map.json
+++ b/custom_components/samsung_smartthings/source_maps/HW-Q910A_source_map.json
@@ -1,0 +1,14 @@
+{
+    "HDMI1": {
+        "sbMode": 3
+    },
+    "HDMI2": {
+        "sbMode": 20
+    },
+    "digital": {
+        "sbMode": 10
+    },
+    "wifi": {
+        "sbMode": 25
+    }
+}

--- a/custom_components/samsung_smartthings/source_maps/HW-Q990C_source_map.json
+++ b/custom_components/samsung_smartthings/source_maps/HW-Q990C_source_map.json
@@ -1,0 +1,14 @@
+{
+    "HDMI1": {
+        "sbMode": 3
+    },
+    "HDMI2": {
+        "sbMode": 21
+    },
+    "digital": {
+        "sbMode": 10
+    },
+    "wifi": {
+        "sbMode": 25
+    }
+}

--- a/custom_components/samsung_smartthings/source_maps/HW-S60T_source_map.json
+++ b/custom_components/samsung_smartthings/source_maps/HW-S60T_source_map.json
@@ -1,0 +1,11 @@
+{
+    "bluetooth": {
+        "sbMode": 4
+    },
+    "digital": {
+        "sbMode": 1
+    },
+    "wifi": {
+        "sbMode": 26
+    }
+}

--- a/custom_components/samsung_smartthings/source_maps/default_source_map.json
+++ b/custom_components/samsung_smartthings/source_maps/default_source_map.json
@@ -1,0 +1,14 @@
+{
+    "HDMI1": {
+        "sbMode": 3
+    },
+    "HDMI2": {
+        "sbMode": 20
+    },
+    "digital": {
+        "sbMode": 10
+    },
+    "wifi": {
+        "sbMode": 25
+    }
+}


### PR DESCRIPTION
This PR enables deterministic source switching functionality for Samsung Soundbars within the Home Assistant UI, a feature that was previously completely unavailable/disabled. As noted in the upstream README, users were left without native UI controls for soundbar source selection and had to rely on manual cycling (`setNextInputSource`) or external hardware workarounds like IR blasters and HDMI-CEC.

This implementation unlocks the source selection UI and leverages the soundbar specific `/sec/networkaudio/soundFrom` endpoint. Since different Samsung models and firmware versions utilize different internal `sbMode` integers for their inputs, I have implemented a lightweight, self learning mapping system. This ensures robust, outofthebox compatibility across the entire soundbar ecosystem without hardcoding fragile variables for every existing model.

### What this PR introduces:

1. **Fixed Feature Mask Flags (`supported_features`):** Updated the feature mask to dynamically append `MediaPlayerEntityFeature.SELECT_SOURCE` when a device possesses the `samsungvd.audioInputSource` capability but lacks `custom.launchapp` (which is typically TV-only). This officially unlocks the native Home Assistant source selection drop-down menu for soundbars.
2. **Dynamic Model Detection:** Cleanly identifies the soundbar's specific model name at runtime (using the OCF `mnmo` attribute) and sanitizes it into a safe string for file handling.
3. **Self Learning Cache System:** Introduces a dedicated `source_maps/` directory. The integration automatically learns a soundbar's source map in the background as the user changes sources (e.g., via the physical remote control). It populates a model specific json file (e.g., `HW-Q910A_source_map.json`).
4. **Self-Healing & Resource Friendly:** Disk I/O is safely offloaded to the Home Assistant executor thread (`async_add_executor_job`) to keep the event loop nonblocking. File writes are restricted once a source mapping is verified, preventing unnecessary disk wear.
5. **Graceful Default Fallback:** Ships with a static inmemory fallback based on verified `sbMode` configurations from a multi-channel Q-series soundbar, generating a `default_source_map.json` on first run to ensure immediate functionality.

---

### 🧠 Architectural Choice: Why individual json files instead of `const.py`?

I deliberately chose isolated json files in a dedicated `source_maps/` directory for two critical reasons:

1. **Live Self Learning Support:** Since the integration dynamically learns and writes new sources to disk at runtime, writing directly to a Python file like `const.py` is not really something i feel okay with. json provides a safe, isolated datastorage that won't interfere with the component's core source code during execution.
2. **Brainless CI Automation:** Having a clean directory containing *only* json files makes future automation incredibly secure and lightweight. A basic GitHub Action can instantly validate incoming crowdsourced soundbar profiles by simply checking that the modified file path is within `source_maps/` and running a basic json schema validation (`json.loads()`). No risky Python AST parsing required, enabling a 100% safe auto merge pipeline.

---

### 📝 Future Documentation & Zero Maintenance Goal

> [!TIP]
> **Regarding the README:** I intentionally left the README unchanged for this initial PR, but I am open to update the "Soundbar Input Source Limitations" section once the logic is approved.
> My plan is to rewrite that section to guide users on how this new self learning mechanism works. I will encourage them to grab their automatically generated `ModelName_source_map.json` from `/config/custom_components/samsung_smartthings/source_maps/` and either post it in an issue or open a quick PR.
> Combined with a simple CI validator script, **this makes expanding the soundbar database 100% zero maintenance for you**, allowing the profile library to grow organically with zero administrative overhead.

### Edge Case Addressed in Code:

I have left a documented note in `@property def source_list` regarding an API telemetry freeze/reload edge case observed specifically when soundbars are set to Bluetooth. The code includes a commented-out section showing how to filter it out if preferred, leaving the ultimate architectural decision up to you.

---

### Credits & Background Reference

The core logic for utilizing the `/sec/networkaudio/soundFrom` endpoint was uncovered thanks to the collaborative troubleshooting in this community issue:

* [PiotrMachowski/Home-Assistant-custom-components-SmartThings-Soundbar #85](https://github.com/PiotrMachowski/Home-Assistant-custom-components-SmartThings-Soundbar/issues/85)

Initially, I created a fork of that integration to validate the concept and ensure the endpoint still worked reliably:

* [TheOddPirate/Smartthings_Soundbar](https://github.com/TheOddPirate/Smartthings_Soundbar)

A couple of days ago, an issue was opened by @awaldram regarding OAuth support, he pointed me toward *this* repository. Realizing this upstream repo is the best and most active place for the feature, I shifted focus to porting the logic over here as a robust, async safe, and self learning solution for everyone. 
Huge thanks to everyone in the linked threads who helped piece this puzzle together!